### PR TITLE
Libkqueue: fix debian package autopkgtest and more

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 12), cmake
 Standards-Version: 4.5.0
 Vcs-Git: https://github.com/mheily/debian-packages.git -b libkqueue
 Vcs-Browser: https://github.com/mheily/debian-packages/tree/libkqueue
-Homepage: https://github.com/mheily/libkqueue/wiki
+Homepage: https://github.com/mheily/libkqueue/
 
 Package: libkqueue0
 Architecture: any

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,3 +1,3 @@
 Tests: kqtest
 Depends: libkqueue0
-Restrictions: allow-stderr
+Restrictions: allow-stderr, build-needed

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,2 +1,3 @@
 Tests: kqtest
 Depends: libkqueue0
+Restrictions: allow-stderr

--- a/debian/tests/kqtest
+++ b/debian/tests/kqtest
@@ -1,7 +1,6 @@
 #!/bin/sh -ex
 
-objdir=$(ls obj-*)
-test -d $objdir
+objdir=$(ls -d obj-*)
 mv $objdir $objdir.BAK
 rc=0
 $objdir.BAK/test/libkqueue-test || rc=1


### PR DESCRIPTION
As https://ci.debian.net/packages/libk/libkqueue/, autopkgtest is failed, so libkqueue never goes into testing (next Debian release target). I've fixed it with tiny changes.

(Of course I can do NMU but PR seems to be better)